### PR TITLE
Get and install mqtt release.

### DIFF
--- a/docker_linux/Dockerfile.build
+++ b/docker_linux/Dockerfile.build
@@ -5,8 +5,8 @@ RUN yum -y install gcc && \
     yum -y install cmake && \
     yum -y install make && \
     yum -y install vim && \
-    yum -y install openssl-devel \
-    yum -y install dos2unix
+    yum -y install openssl-devel && \
+    yum -y install wget
 
 RUN yum clean all
 
@@ -17,10 +17,13 @@ RUN mkdir -p /q
 ENV QHOME /q
 ENV PATH /q/l64:$PATH
 ENV LD_LIBRARY_PATH /usr/local/lib:$LD_LIBRARY_PATH
-ENV PAHO_HOME=/source/mqtt
+
+RUN cd /source/paho.mqtt.c && wget https://github.com/eclipse/paho.mqtt.c/archive/v1.3.2.tar.gz && tar xvf v1.3.2.tar.gz && cd paho.mqtt.c-1.3.2 && make install
+
+ENV PAHO_HOME=/source/paho.mqtt.c/paho.mqtt.c-1.3.2/
 
 COPY mqtt_build.sh /source
-RUN dos2unix /source/mqtt_build.sh
+RUN /source/mqtt_build.sh
 
 WORKDIR /source
 

--- a/docker_linux/mqtt_build.bat
+++ b/docker_linux/mqtt_build.bat
@@ -1,10 +1,9 @@
 SETLOCAL
 
-SET MQTT_SOURCE="c:\git\mqtt"
-SET PAHO_MQTT="c:\git\paho.mqtt.c"
-SET QHOME_LINUX="c:\linux_shared\q"
+SET MQTT_SOURCE="C:\Users\guest\Development\mqtt"
+SET QHOME_LINUX="C:\q"
 
 docker build -f Dockerfile.build -t mqtt-dev .
-docker run --rm -it -v %MQTT_SOURCE%:/source/mqtt -v %PAHO_MQTT%:/source/paho.mqtt.c -v %QHOME_LINUX%:/q mqtt-dev /bin/bash -c /source/mqtt_build.sh
+docker run --rm -it -v %MQTT_SOURCE%:/source/mqtt -v %QHOME_LINUX%:/q mqtt-dev /bin/bash -c /source/mqtt_build.sh
 
 ENDLOCAL

--- a/docker_linux/mqtt_build.sh
+++ b/docker_linux/mqtt_build.sh
@@ -1,7 +1,5 @@
 #/bin/bash
 
-make --directory /source/paho.mqtt.c
-make install --directory /source/paho.mqtt.c
 make --directory /source/mqtt
 make install --directory /source/mqtt
 


### PR DESCRIPTION
Not the final solution, but a small improvement.
Instead of looking for a src code download on local machine, the docker build will download & build an official version (helps with sym links/etc also).

This doesn't currently deal with fully building against an official release (as it'll currently fail due to the makefile depending upon a build file structure).
