### PR TITLE
Addition of graceful method to disconnect

### DIFF
--- a/q/mqtt.q
+++ b/q/mqtt.q
@@ -1,9 +1,12 @@
 \d .mqtt
-connX :`mqtt 2:(`connX;3);
+connX:`mqtt 2:(`connX;3);
 init :`mqtt 2:(`init;1);
 pubx :`mqtt 2:(`pub ;4);
 sub  :`mqtt 2:(`sub ;1);
 unsub:`mqtt 2:(`unsub;1);
+isConnected:`mqtt 2:(`isConnected;1);
+disconnect :`mqtt 2:(`disconnect;1);
+
 
 pub:.mqtt.pubx[;;1;0]
 conn:{[tcpconn;pname;opt]connX[tcpconn;pname](enlist[`]!enlist(::)),opt}

--- a/src/mqtt.c
+++ b/src/mqtt.c
@@ -154,7 +154,7 @@ EXP K disconnect(K timeout){
     MQTTClient_disconnect(client,(time_t)timeout->i);
     MQTTClient_destroy(&client);
   }
-  return kp("Client successfully destroyed");
+  return (K)0;
 }
 
 EXP K isConnected(K UNUSED(x)){

--- a/src/mqtt.c
+++ b/src/mqtt.c
@@ -143,6 +143,28 @@ EXP K connX(K tcpconn,K pname, K opt){
   return (K)0;
 }
 
+/* Disconnect from an mqtt client
+ * timeout = length of time in ms to allow for the client to clean up prior to disconnection
+*/
+
+EXP K disconnect(K timeout){
+  if(!MQTTClient_isConnected(client))
+    return krr((S)"No client is not currently connected");
+  else{
+    MQTTClient_disconnect(client,(time_t)timeout->i);
+    MQTTClient_destroy(&client);
+  }
+  return kp("Client successfully destroyed");
+}
+
+EXP K isConnected(K UNUSED(x)){
+  if(!MQTTClient_isConnected(client))
+    return kb(0);
+  else
+    return kb(1);
+}
+
+
 /* Publish a message to a specified topic
  * topic = topic name as a symbol
  * msg   = message content as a string

--- a/src/mqtt.c
+++ b/src/mqtt.c
@@ -149,7 +149,7 @@ EXP K connX(K tcpconn,K pname, K opt){
 
 EXP K disconnect(K timeout){
   if(!MQTTClient_isConnected(client))
-    return krr((S)"No client is not currently connected");
+    return krr((S)"No client is currently connected");
   else{
     MQTTClient_disconnect(client,(time_t)timeout->i);
     MQTTClient_destroy(&client);


### PR DESCRIPTION
This PR closes #33 

Currently the interface does not allow a user to disconnect 'gracefully' from the single client to which it is connected.

This addition allows a process which is connected to an MQTT broker to disconnect accordingly. The following indicates the behaviour of the interface and the 2 functions added
```
// Is my process currently connected to a broker?
.mqtt.isConnected[]

// Disconnect from a broker to which you are currently connected
/* timeout in milliseconds to allow the handling of in flight messages
.mqtt.disconnect[timeout]
```

Example usage:

```
$ q mqtt.q
KDB+ 4.0 2020.04.16 Copyright (C) 1993-2020 Kx Systems

// Check is connected logic
q).mqtt.isConnected[]
0b
q)hst:`$"tcp://localhost:1883"
q).mqtt.conn[hst;`src;()!()]
q).mqtt.isConnected[]
1b

// Highlight current behaviour by attempting to connect again
// results in a disconn callback
q).mqtt.conn[hst;`src;()!()]
q)(`disconn;())

// Gracefully disconnect and reconnect
q).mqtt.disconnect[1000]
"Client successfully destroyed"
q).mqtt.conn[hst;`src;()!()]

// Attempt to disconnect twice
q).mqtt.disconnect[1000]
"Client successfully destroyed"
q).mqtt.disconnect[1000]
'"No client is currently connected"
  [0] .mqtt.disconnect[1000]
      ^
```