### PR TITLE
WIP: Enable last will

### DIFF
--- a/src/mqtt.c
+++ b/src/mqtt.c
@@ -51,6 +51,16 @@ static char* getStringFromList(K propValues,int row, const char** value, char* e
   return errStr;
 }
 
+static char* getCharArrayAsStringFromList(K propValues,int row, const char** value, char* errStr)
+{
+  if ((int)(kK(propValues)[row]->t) == KC)
+  {
+    *value = strndup((const char *)kC(kK(propValues)[row]),kK(propValues)[row]->n);
+    return 0;
+  }
+  return errStr;
+}
+
 static char* getIntFromList(K propValues,int row, int* value, char* errStr)
 {
   if ((int)(kK(propValues)[row]->t) == -KI)
@@ -122,7 +132,7 @@ EXP K connX(K tcpconn,K pname, K opt){
     else if (strcmp(kS(propNames)[row],"lastWillQos")==0)
       errStr = getIntFromList(propValues,row,&will_opts.qos,"lastWillQos type incorrect");
     else if (strcmp(kS(propNames)[row],"lastWillMessage")==0)
-      errStr = getStringFromList(propValues,row,&will_opts.message,"lastWillMessage type incorrect");
+      errStr = getCharArrayAsStringFromList(propValues,row,&will_opts.message,"lastWillMessage type incorrect");
     else if (strcmp(kS(propNames)[row],"lastWillRetain")==0)
       errStr = getIntFromList(propValues,row,&will_opts.retained,"lastWillRetain type incorrect");
     else

--- a/src/mqtt.c
+++ b/src/mqtt.c
@@ -77,6 +77,7 @@ EXP K connX(K tcpconn,K pname, K opt){
     return krr("options");
   client = 0;
 
+  MQTTClient_willOptions will_opts = MQTTClient_willOptions_initializer;
   MQTTClient_connectOptions conn_opts = MQTTClient_connectOptions_initializer;
 
   K propNames = (kK(opt)[0]);
@@ -115,6 +116,15 @@ EXP K connX(K tcpconn,K pname, K opt){
       errStr = getIntFromList(propValues,row,&conn_opts.maxInflightMessages,"maxInflightMessages type incorrect");
     else if (strcmp(kS(propNames)[row],"cleanstart")==0)
       errStr = getIntFromList(propValues,row,&conn_opts.cleanstart,"cleanstart type incorrect");
+    else if (strcmp(kS(propNames)[row],"lastWillTopic")==0){
+      conn_opts.will = &will_opts;
+      errStr = getStringFromList(propValues,row,&will_opts.topicName,"lastWillTopic type incorrect");}
+    else if (strcmp(kS(propNames)[row],"lastWillQos")==0)
+      errStr = getIntFromList(propValues,row,&will_opts.qos,"lastWillQos type incorrect");
+    else if (strcmp(kS(propNames)[row],"lastWillMessage")==0)
+      errStr = getStringFromList(propValues,row,&will_opts.message,"lastWillMessage type incorrect");
+    else if (strcmp(kS(propNames)[row],"lastWillRetain")==0)
+      errStr = getIntFromList(propValues,row,&will_opts.retained,"lastWillRetain type incorrect");
     else
       errStr = "Unsupported conn opt name in dictionary";
   }


### PR DESCRIPTION
Enable the library to use last will during connection

https://www.eclipse.org/paho/files/mqttdoc/MQTTClient/html/struct_m_q_t_t_client__will_options.html

To test:

```bash
$ mosquitto_sub -v -t "test"
```

```q
\l mqtt.q
opts:`lastWillTopic`lastWillQos`lastWillMessage`lastWillRetain!(`test;2i;"disconnect";0i)
.mqtt.conn[`localhost:1883;`src;opts]
\\
```

`mosquitto_sub` will print:

```bash
test disconnect
```

