### PR TITLE
Revert "WIP: Enable last will"

### DIFF
--- a/src/mqtt.c
+++ b/src/mqtt.c
@@ -51,16 +51,6 @@ static char* getStringFromList(K propValues,int row, const char** value, char* e
   return errStr;
 }
 
-static char* getCharArrayAsStringFromList(K propValues,int row, const char** value, char* errStr)
-{
-  if ((int)(kK(propValues)[row]->t) == KC)
-  {
-    *value = strndup((const char *)kC(kK(propValues)[row]),kK(propValues)[row]->n);
-    return 0;
-  }
-  return errStr;
-}
-
 static char* getIntFromList(K propValues,int row, int* value, char* errStr)
 {
   if ((int)(kK(propValues)[row]->t) == -KI)
@@ -87,7 +77,6 @@ EXP K connX(K tcpconn,K pname, K opt){
     return krr("options");
   client = 0;
 
-  MQTTClient_willOptions will_opts = MQTTClient_willOptions_initializer;
   MQTTClient_connectOptions conn_opts = MQTTClient_connectOptions_initializer;
 
   K propNames = (kK(opt)[0]);
@@ -126,15 +115,6 @@ EXP K connX(K tcpconn,K pname, K opt){
       errStr = getIntFromList(propValues,row,&conn_opts.maxInflightMessages,"maxInflightMessages type incorrect");
     else if (strcmp(kS(propNames)[row],"cleanstart")==0)
       errStr = getIntFromList(propValues,row,&conn_opts.cleanstart,"cleanstart type incorrect");
-    else if (strcmp(kS(propNames)[row],"lastWillTopic")==0){
-      conn_opts.will = &will_opts;
-      errStr = getStringFromList(propValues,row,&will_opts.topicName,"lastWillTopic type incorrect");}
-    else if (strcmp(kS(propNames)[row],"lastWillQos")==0)
-      errStr = getIntFromList(propValues,row,&will_opts.qos,"lastWillQos type incorrect");
-    else if (strcmp(kS(propNames)[row],"lastWillMessage")==0)
-      errStr = getCharArrayAsStringFromList(propValues,row,&will_opts.message,"lastWillMessage type incorrect");
-    else if (strcmp(kS(propNames)[row],"lastWillRetain")==0)
-      errStr = getIntFromList(propValues,row,&will_opts.retained,"lastWillRetain type incorrect");
     else
       errStr = "Unsupported conn opt name in dictionary";
   }


### PR DESCRIPTION
Reverts KxSystems/mqtt#39
One problem - the mac build is failing on Travis.
The problem is the use of strndup which I believe is a GNU extension that isn't support on earlier OS X builds.
We could bump the travis OS X image (as is done by arrowkdb) but it's probably easier to change the strndup to a malloc + memcpy (or just use plain strdup if the strings don't contain \0 chars)