### PR TITLE
enable SSL/TLS connections

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,18 +46,6 @@ set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -DKXVER=3")
 file(DOWNLOAD "https://github.com/KxSystems/kdb/raw/master/c/c/k.h" "${PROJECT_SOURCE_DIR}/include/k.h")
 
 # Find dependencies
-find_library(MQTT3A_LIBRARY
-    NAMES paho-mqtt3a
-    HINTS "$ENV{MQTT_INSTALL_DIR}/lib/"
-)
-find_library(MQTT3AS_LIBRARY
-    NAMES paho-mqtt3as
-    HINTS "$ENV{MQTT_INSTALL_DIR}/lib/"
-)
-find_library(MQTT3C_LIBRARY
-    NAMES paho-mqtt3c
-    HINTS "$ENV{MQTT_INSTALL_DIR}/lib/"
-)
 find_library(MQTT3CS_LIBRARY
     NAMES paho-mqtt3cs
     HINTS "$ENV{MQTT_INSTALL_DIR}/lib/"
@@ -91,7 +79,7 @@ IF(APPLE)
 endif()
 
 # Link dependent libraries
-target_link_libraries(${MY_LIBRARY_NAME} ${MQTT3A_LIBRARY} ${MQTT3AS_LIBRARY} ${MQTT3C_LIBRARY} ${MQTT3CS_LIBRARY} ${Q_LIBRARY})
+target_link_libraries(${MY_LIBRARY_NAME} ${MQTT3CS_LIBRARY} ${Q_LIBRARY})
 
 ##%% Installation %%##vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv#
 

--- a/src/mqtt.c
+++ b/src/mqtt.c
@@ -93,6 +93,7 @@ EXP K connX(K tcpconn,K pname, K opt){
 
   MQTTClient_willOptions will_opts = MQTTClient_willOptions_initializer;
   MQTTClient_connectOptions conn_opts = MQTTClient_connectOptions_initializer;
+  MQTTClient_SSLOptions ssl_opts = MQTTClient_SSLOptions_initializer;
 
   K propNames = (kK(opt)[0]);
   K propValues = (kK(opt)[1]);
@@ -139,6 +140,15 @@ EXP K connX(K tcpconn,K pname, K opt){
       errStr = getCharArrayAsStringFromList(propValues,row,&will_opts.message,"lastWillMessage type incorrect");
     else if (strcmp(kS(propNames)[row],"lastWillRetain")==0)
       errStr = getIntFromList(propValues,row,&will_opts.retained,"lastWillRetain type incorrect");
+    else if (strcmp(kS(propNames)[row],"trustStore")==0){
+      conn_opts.ssl = &ssl_opts;
+      errStr = getStringFromList(propValues,row,&ssl_opts.trustStore,"trustStore type incorrect");}
+    else if (strcmp(kS(propNames)[row],"keyStore")==0)
+      errStr = getStringFromList(propValues,row,&ssl_opts.keyStore,"keyStore type incorrect");
+    else if (strcmp(kS(propNames)[row],"privateKey")==0)
+      errStr = getStringFromList(propValues,row,&ssl_opts.privateKey,"privateKey type incorrect");
+    else if (strcmp(kS(propNames)[row],"sslCApath")==0)
+      errStr = getStringFromList(propValues,row,&ssl_opts.CApath,"CApath type incorrect");
     else
       errStr = "Unsupported conn opt name in dictionary";
   }


### PR DESCRIPTION
Enable the interface lib to use SSL/TLS connections
https://www.eclipse.org/paho/files/mqttdoc/MQTTClient/html/struct_m_q_t_t_client___s_s_l_options.html

```
q)opts:`username`password`trustStore`keyStore`privateKey!(`phil;(`$"password123");(`$"/home/phil/testCerts/ca/ca.crt");(`$"/home/phil/testCerts/client/client.crt");(`$"/home/phil/testCerts/client/client.key"))
q).mqtt.conn[`$"ssl://localhost:8883";`src;opts]
q).mqtt.pub[`topic1;"This is a test message"]
1
q)(`msgsent;1)
```

tcp connections

```
q).mqtt.conn[`$"localhost:1883";`src;()!()]
q).mqtt.pub[`topic1;"This is a test message"]
1
q)(`msgsent;1)

```

With the existing build, mqttkdb.so is linked to:
https://github.com/KxSystems/mqtt/blob/master/CMakeLists.txt#L94

- libmqtt3a.so - asynchronous
- libmqtt3as.so - asynchronous with SSL
- libmqtt3c.so - "classic" / synchronous
- libmqtt3cs.so - "classic" / synchronous with SSL

It appeared only libmqtt3c.so was being linked: (which I am not sure why) 
```
phil@LPTP1932:~/repos/mqtt/build$ ldd ~/q/l64/mqttkdb.so
        linux-vdso.so.1 (0x00007ffdff9d2000)
        libpaho-mqtt3c.so.1 => /usr/local/lib/libpaho-mqtt3c.so.1 (0x00007fdb2952c000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fdb2933a000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007fdb29317000)
        /lib64/ld-linux-x86-64.so.2 (0x00007fdb29565000)
```

The async libs were not linked at all when testing the build without the sync libs. 
libmqtt3cs.so lib appears to satisfy the use cases for the interface
