### PR TITLE
Addition of ssl lib for SSL/TLS. Ref #51

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ project(mqttkdb C)
 
 # Name of shared object
 set(MY_LIBRARY_NAME mqttkdb)
+set(MY_SSL_LIBRARY_NAME mqttkdb_ssl)
 
 # Dispay settings
 message(STATUS "Generator : ${CMAKE_GENERATOR}")
@@ -31,9 +32,17 @@ add_library(${MY_LIBRARY_NAME} SHARED
     src/mqtt.c
     src/socketpair.c
 )
+add_library(${MY_SSL_LIBRARY_NAME} SHARED
+    src/mqtt.c
+    src/socketpair.c
+)
 
 # Specify include directories
 target_include_directories (${MY_LIBRARY_NAME} PRIVATE
+    ${PROJECT_SOURCE_DIR}/include
+    $ENV{MQTT_INSTALL_DIR}/include
+)
+target_include_directories (${MY_SSL_LIBRARY_NAME} PRIVATE
     ${PROJECT_SOURCE_DIR}/include
     $ENV{MQTT_INSTALL_DIR}/include
 )
@@ -48,6 +57,10 @@ file(DOWNLOAD "https://github.com/KxSystems/kdb/raw/master/c/c/k.h" "${PROJECT_S
 # Find dependencies
 find_library(MQTT3C_LIBRARY
     NAMES paho-mqtt3c
+    HINTS "$ENV{MQTT_INSTALL_DIR}/lib/"
+)
+find_library(MQTT3CS_LIBRARY
+    NAMES paho-mqtt3cs
     HINTS "$ENV{MQTT_INSTALL_DIR}/lib/"
 )
 
@@ -72,14 +85,19 @@ if(APPLE)
 endif()
 set_target_properties(${MY_LIBRARY_NAME} PROPERTIES PREFIX "")
 set_target_properties(${MY_LIBRARY_NAME} PROPERTIES SUFFIX ${CMAKE_SHARED_LIBRARY_SUFFIX})
+set_target_properties(${MY_SSL_LIBRARY_NAME} PROPERTIES PREFIX "")
+set_target_properties(${MY_SSL_LIBRARY_NAME} PROPERTIES SUFFIX ${CMAKE_SHARED_LIBRARY_SUFFIX})
+target_compile_definitions(${MY_SSL_LIBRARY_NAME} PRIVATE -DMQTT_SSL)
 
 # Link flag
 IF(APPLE)
    set_target_properties(${MY_LIBRARY_NAME} PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
+   set_target_properties(${MY_SSL_LIBRARY_NAME} PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
 endif()
 
 # Link dependent libraries
 target_link_libraries(${MY_LIBRARY_NAME} ${MQTT3C_LIBRARY} ${Q_LIBRARY})
+target_link_libraries(${MY_SSL_LIBRARY_NAME} ${MQTT3CS_LIBRARY} ${Q_LIBRARY})
 
 ##%% Installation %%##vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv#
 
@@ -116,7 +134,15 @@ add_custom_command(TARGET ${MY_LIBRARY_NAME}
     COMMAND ${CMAKE_COMMAND} -E copy "$<TARGET_FILE:${MY_LIBRARY_NAME}>" ${PROJECT_BINARY_DIR}/${CMAKE_PROJECT_NAME}/lib/${MY_LIBRARY_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX}
     DEPENDS ${MY_LIBRARY_NAME}
 )
+add_custom_command(TARGET ${MY_SSL_LIBRARY_NAME}
+    POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy "$<TARGET_FILE:${MY_SSL_LIBRARY_NAME}>" ${PROJECT_BINARY_DIR}/${CMAKE_PROJECT_NAME}/lib/${MY_SSL_LIBRARY_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX}
+    DEPENDS ${MY_SSL_LIBRARY_NAME}
+)
+
+
 
 # Install at Release
 install(TARGETS ${MY_LIBRARY_NAME} DESTINATION "$ENV{QHOME}/${OSFLAG}${BITNESS}/" CONFIGURATIONS Release)
+install(TARGETS ${MY_SSL_LIBRARY_NAME} DESTINATION "$ENV{QHOME}/${OSFLAG}${BITNESS}/" CONFIGURATIONS Release)
 install(DIRECTORY "q/" DESTINATION "$ENV{QHOME}" CONFIGURATIONS Release)

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ MQTT is used commonly for constrained devices with low-bandwidth, high-latency o
         $ export DYLD_LIBRARY_PATH=/Users/jim/Eclipse-Paho-MQTT-C/lib/:$DYLD_LIBRARY_PATH
       
         ```
-   - Windows: Add the `paho-mqtt3c.dll` to the kdb+ lib directory e.g. `C:\q\w64` for 64-bit.
+   - Windows: Add the `paho-mqtt3c.dll` and `paho-mqtt3cs.dll` to the kdb+ lib directory e.g. `C:\q\w64` for 64-bit.
 3. Download the latest release of the mqtt interface from our [releases page](https://github.com/KxSystems/mqtt). To install shared library and q files, use:
 
         # Linux/MacOS
@@ -65,7 +65,7 @@ MQTT is used commonly for constrained devices with low-bandwidth, high-latency o
      ```bash
 
      ]$ mkdir paho_mqtt_c
-     ]$ tar xzf Eclipse-Paho-MQTT-C-1.3.8-Linux.tar.gz -C paho_mqtt_c/ --strip-components=1
+     ]$ tar xzf Eclipse-Paho-MQTT-C-1.3.11-Linux.tar.gz -C paho_mqtt_c/ --strip-components=1
      ]$ cd paho_mqtt_c/
      paho_mqtt_c]$ export MQTT_INSTALL_DIR=$(pwd)
 
@@ -102,11 +102,12 @@ MQTT is used commonly for constrained devices with low-bandwidth, high-latency o
      ```bat
 
      > mkdir paho_mqtt_c
-     > 7z x eclipse-paho-mqtt-c-win64-1.3.8.zip -opaho_mqtt_c
+     > 7z x eclipse-paho-mqtt-c-win64-1.3.11.zip -opaho_mqtt_c
      > cd paho_mqtt_c
      paho_mqtt_c> set MQTT_INSTALL_DIR=%cd%
      paho_mqtt_c> cd %QHOME%\w64
      w64> MKLINK paho-mqtt3c.dll %MQTT_INSTALL_DIR%\lib\paho-mqtt3c.dll
+     w64> MKLINK paho-mqtt3cs.dll %MQTT_INSTALL_DIR%\lib\paho-mqtt3cs.dll
 
      ```
 

--- a/docker_linux/Dockerfile.alpine
+++ b/docker_linux/Dockerfile.alpine
@@ -45,7 +45,7 @@ RUN apk add --update && \
     apk del make && \
     apk del wget && \
 	apk del build-base && \	
-    rm -rf /source/mqtt_build.sh /source/paho.mqtt.c /source/v1.3.9* /source/mqtt/CmakeLists.txt 
+    rm -rf /source/mqtt_build.sh /source/paho.mqtt.c /source/v1.3.11* /source/mqtt/CmakeLists.txt
 	
 ## Update this section here to add kdb+
 #COPY q/k4.lic /q/

--- a/docker_linux/build_libpaho.sh
+++ b/docker_linux/build_libpaho.sh
@@ -2,8 +2,8 @@
 	
 cd /source
 
-wget https://github.com/eclipse/paho.mqtt.c/archive/refs/tags/v1.3.9.tar.gz
-tar xvf v1.3.9.tar.gz -C ./paho.mqtt.c --strip-components=1
+wget https://github.com/eclipse/paho.mqtt.c/archive/refs/tags/v1.3.11.tar.gz
+tar xvf v1.3.11.tar.gz -C ./paho.mqtt.c --strip-components=1
 
 cd paho.mqtt.c
 

--- a/src/mqtt.c
+++ b/src/mqtt.c
@@ -2,7 +2,11 @@
 #include <winsock2.h>
 #include <windows.h>
 #pragma comment(lib,"ws2_32.lib")
+#ifdef MQTT_SSL
+#pragma comment(lib,"paho-mqtt3cs.lib")
+#else
 #pragma comment(lib,"paho-mqtt3c.lib")
+#endif
 #pragma comment(lib,"q.lib")
 #define EXP __declspec(dllexport)
 static SOCKET spair[2];


### PR DESCRIPTION
New library addition `mqttkdb_ssl.so` which allows both TLS/SSL and non-TLS/SSL connections.
Differs from existing `mqttkdb.so` in that it requires the mqtt library `libpaho-mqtt3cs` and openssl libs to be installed on the system.
The `mqttkdb.so` is still provided for non TLS/SSL users, preventing them from having to install TLS/SSL libs on their system.

When using `mqttkdb_ssl.so` :
* the connection URI needs to change from `tcp://` to `ssl://` in order to work with SSL/TLS connections
* remember to alter q script to load the `mqttkdb_ssl.so` instead of `mqttkdb.so`
* requires SSL/TLS specific connection params (in addition to any existing params e.g. username/password)

New connection params

| Name | Type | Details |
| ----------- | ----------- | ----------- | 
| trustStore | sym | The file in PEM format containing the public digital certificates trusted by the client. |
| keyStore | sym | The file in PEM format containing the public certificate chain of the client. It may also include the client's private key. |
| privateKey | sym | If not included in the sslKeyStore, this setting points to the file in PEM format containing the client's private key. |
| privateKeyPassword | sym | The password to load the client's privateKey if encrypted. |
| enabledCipherSuites | sym | The list of cipher suites that the client will present to the server during the SSL handshake. For a full explanation of the cipher list format, please see the OpenSSL on-line documentation: http://www.openssl.org/docs/apps/ciphers.html#CIPHER_LIST_FORMAT If this setting is ommitted, its default value will be "ALL", that is, all the cipher suites -excluding those offering no encryption- will be considered. This setting can be used to set an SSL anonymous connection ("aNULL" string value, for instance) |
| enableServerCertAuth | int/long | True/False (i.e. 1/0) option to enable verification of the server certificate |
| sslVersion | int/long | The SSL/TLS version to use. Specify one of MQTT_SSL_VERSION_DEFAULT (0), MQTT_SSL_VERSION_TLS_1_0 (1), MQTT_SSL_VERSION_TLS_1_1 (2) or MQTT_SSL_VERSION_TLS_1_2 (3). Only used if struct_version is >= 1 |
| verify | int/long | Whether to carry out post-connect checks, including that a certificate matches the given host name. |
| CApath | sym | From the OpenSSL documentation: If CApath is not NULL, it points to a directory containing CA certificates in PEM format |


Example
```
opts:`trustStore`enableServerCertAuth`verify`sslVersion!((`$"/mqttq/server-certs/ca.crt");(0i);(0i);(0i))
.mqtt.conn[`$"ssl://localhost:1883";`rcv;opts];
```
