### PR TITLE
Update paho lib to 1.3.12 from 1.3.11

### DIFF
--- a/docker_linux/Dockerfile.alpine
+++ b/docker_linux/Dockerfile.alpine
@@ -45,7 +45,7 @@ RUN apk add --update && \
     apk del make && \
     apk del wget && \
 	apk del build-base && \	
-    rm -rf /source/mqtt_build.sh /source/paho.mqtt.c /source/v1.3.11* /source/mqtt/CmakeLists.txt
+    rm -rf /source/mqtt_build.sh /source/paho.mqtt.c /source/v1.3.12* /source/mqtt/CmakeLists.txt
 	
 ## Update this section here to add kdb+
 #COPY q/k4.lic /q/

--- a/docker_linux/Dockerfile.centos7
+++ b/docker_linux/Dockerfile.centos7
@@ -6,6 +6,7 @@ RUN yum -y install gcc && \
     yum -y install make && \
     yum -y install vim && \
     yum -y install openssl-devel && \
+    yum -y install unzip && \
     yum -y install wget
 
 RUN yum clean all
@@ -18,11 +19,11 @@ ENV QHOME /q
 ENV PATH /q/l64:$PATH
 ENV LD_LIBRARY_PATH /usr/local/lib:$LD_LIBRARY_PATH
 
-RUN cd /source && wget https://github.com/eclipse/paho.mqtt.c/releases/download/v1.3.11/Eclipse-Paho-MQTT-C-1.3.11-Linux.tar.gz && tar xvf Eclipse-Paho-MQTT-C-1.3.11-Linux.tar.gz -C ./paho.mqtt.c --strip-components=1
+RUN cd /source && wget https://github.com/eclipse/paho.mqtt.c/releases/download/v1.3.12/Eclipse-Paho-MQTT-C-1.3.12-Linux.tar.gz.zip && unzip Eclipse-Paho-MQTT-C-1.3.12-Linux.tar.gz.zip && tar xvf Eclipse-Paho-MQTT-C-1.3.12-Linux.tar.gz -C ./paho.mqtt.c --strip-components=1
 ENV BUILD_HOME /source/paho.mqtt.c
 
 COPY mqtt_build.sh /source
-RUN /source/mqtt_build.sh
+RUN chmod u+x /source/mqtt_build.sh && /source/mqtt_build.sh
 
 RUN cd /tmp/ && wget https://cmake.org/files/v3.12/cmake-3.12.3.tar.gz && tar zxvf cmake-3.* && cd cmake-3.* && ./bootstrap --prefix=/usr/local && make && make install && rm /tmp/cmake-3.12.3.tar.gz
 RUN yum -y install epel-release && yum -y install mosquitto

--- a/docker_linux/build_libpaho.sh
+++ b/docker_linux/build_libpaho.sh
@@ -2,8 +2,8 @@
 	
 cd /source
 
-wget https://github.com/eclipse/paho.mqtt.c/archive/refs/tags/v1.3.11.tar.gz
-tar xvf v1.3.11.tar.gz -C ./paho.mqtt.c --strip-components=1
+wget https://github.com/eclipse/paho.mqtt.c/archive/refs/tags/v1.3.12.tar.gz
+tar xvf v1.3.12.tar.gz -C ./paho.mqtt.c --strip-components=1
 
 cd paho.mqtt.c
 

--- a/travis_setup.sh
+++ b/travis_setup.sh
@@ -3,14 +3,16 @@
 mkdir cbuild
 
 if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-  wget https://github.com/eclipse/paho.mqtt.c/releases/download/v1.3.11/Eclipse-Paho-MQTT-C-1.3.11-Darwin.tar.gz
-  tar xvf Eclipse-Paho-MQTT-C-1.3.11-Darwin.tar.gz -C ./cbuild --strip-components=1
+  wget https://github.com/eclipse/paho.mqtt.c/releases/download/v1.3.12/Eclipse-Paho-MQTT-C-1.3.12-Darwin.tar.gz.zip
+  unzip Eclipse-Paho-MQTT-C-1.3.12-Darwin.tar.gz.zip
+  tar xvf Eclipse-Paho-MQTT-C-1.3.12-Darwin.tar.gz -C ./cbuild --strip-components=1
 elif [ "$TRAVIS_OS_NAME" == "linux" ]; then
-  wget https://github.com/eclipse/paho.mqtt.c/releases/download/v1.3.11/Eclipse-Paho-MQTT-C-1.3.11-Linux.tar.gz
-  tar xvf Eclipse-Paho-MQTT-C-1.3.11-Linux.tar.gz -C ./cbuild --strip-components=1
+  wget https://github.com/eclipse/paho.mqtt.c/releases/download/v1.3.12/Eclipse-Paho-MQTT-C-1.3.12-Linux.tar.gz.zip
+  unzip Eclipse-Paho-MQTT-C-1.3.12-Linux.tar.gz.zip
+  tar xvf Eclipse-Paho-MQTT-C-1.3.12-Linux.tar.gz -C ./cbuild --strip-components=1
 elif [ "$TRAVIS_OS_NAME" == "windows" ]; then
-  wget https://github.com/eclipse/paho.mqtt.c/releases/download/v1.3.11/eclipse-paho-mqtt-c-win64-1.3.11.zip
-   7z x -ocbuild eclipse-paho-mqtt-c-win64-1.3.11.zip
+  wget https://github.com/eclipse/paho.mqtt.c/releases/download/v1.3.12/eclipse-paho-mqtt-c-win64-1.3.12.zip
+   7z x -ocbuild eclipse-paho-mqtt-c-win64-1.3.12.zip
 else
   echo "$TRAVIS_OS_NAME is currently not supported"  
 fi


### PR DESCRIPTION
They seem to have accidently created a tar.gz.zip instead of a tar.gz on their release page for this version (hence the unzip)