### PR TITLE
new func subx. add QoS docs. Fixes #56

### DIFF
--- a/q/mqtt.q
+++ b/q/mqtt.q
@@ -3,13 +3,14 @@
 connX:`mqttkdb 2:(`connX;3);
 init :`mqttkdb 2:(`init;1);
 pubx :`mqttkdb 2:(`pub ;4);
-sub  :`mqttkdb 2:(`sub ;1);
+subx :`mqttkdb 2:(`sub ;2);
 unsub:`mqttkdb 2:(`unsub;1);
 isConnected:`mqttkdb 2:(`isConnected;1);
 disconnect :`mqttkdb 2:(`disconnect;1);
 
 
 pub:.mqtt.pubx[;;1;0];
+sub:.mqtt.subx[;1];
 conn:{[tcpconn;pname;opt]connX[tcpconn;pname](enlist[`]!enlist(::)),opt};
 msgsent:{0N!(`msgsent;x);};
 disconn:{0N!(`disconn;x);};

--- a/src/mqtt.c
+++ b/src/mqtt.c
@@ -279,13 +279,27 @@ EXP K pub(K topic, K msg, K kqos, K kret){
 /* Subscribe to a topic
  * topic = topic name as a symbol
 */
-EXP K sub(K topic){
+EXP K sub(K topic,K kqos){
   int err;
+  long qos;
   if(topic->t != -KS)
     return krr("topic type");
   if(client == 0)
     return krr("not connected");
-  if(MQTTCLIENT_SUCCESS != (err = MQTTClient_subscribe(client, topic->s, 1)))
+  switch(kqos->t){
+    case -KH:
+      qos = kqos->h;
+      break;
+    case -KI:
+      qos = kqos->i;
+      break;
+    case -KJ:
+      qos = kqos->j;
+      break;
+    default:
+      return krr("qos type");
+  }
+  if(MQTTCLIENT_SUCCESS != (err = MQTTClient_subscribe(client, topic->s, qos)))
     return krr((S)MQTTClient_strerror(err));
   return (K)0;
 }


### PR DESCRIPTION
Addition of subx to allow user to choose quality of service level Docs on quality of service levels (for publishing and subscribing) - affects performance/quality/throughput Prev sub method hardcoded with a QoS level.
Existing sub functionality not changed (calls subx).