### PR TITLE
.travis.yml deploy artifact change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,7 @@ deploy:
   token: "$GITHUB_APIKEY"
   file: "$FILE_NAME"
   dpl_version: 1.10.16
-  deploy.skip_cleanup: true
+  skip_cleanup: true
   on:
     tags: true
     condition: $TRAVIS_OS_NAME = windows || $TRAVIS_OS_NAME = osx || ($TRAVIS_DIST = xenial && $TRAVIS_OS_NAME = linux)

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,6 +95,7 @@ deploy:
   token: "$GITHUB_APIKEY"
   file: "$FILE_NAME"
   dpl_version: 1.10.16
+  deploy.skip_cleanup: true
   on:
     tags: true
     condition: $TRAVIS_OS_NAME = windows || $TRAVIS_OS_NAME = osx || ($TRAVIS_DIST = xenial && $TRAVIS_OS_NAME = linux)


### PR DESCRIPTION
Fix for deploy artefacts missing, log says

Cleaning up git repository with `git stash --all`. If you need build artifacts for deployment, set `deploy.skip_cleanup: true`. See https://docs.travis-ci.com/user/deployment#Uploading-Files-and-skip_cleanup. Saved working directory and index state WIP on (no branch): e963af6 travis fix for various ruby/gem errors on deploy (#74) mqttkdb-osx-1.4.1.tgz does not exist.